### PR TITLE
Fix Right Clicking Parasite Entities

### DIFF
--- a/src/main/java/srpmixins/config/folders/VariousConfig.java
+++ b/src/main/java/srpmixins/config/folders/VariousConfig.java
@@ -73,7 +73,7 @@ public class VariousConfig {
     @MixinConfig.MixinToggle(lateMixin = "mixins.srpmixins.srp.emptywhitelistfix.json", defaultValue = true)
     public boolean fixEmptyWhitelist = true;
 
-    @Config.Comment("Some parasites have broken right click handling when looking at them and will cancel all right click actions such as raising shields and drinking potions. This fixes it.")
+    @Config.Comment("Some parasites have broken right click handling. When looking at them, all right click actions such as raising shields and drinking potions will get cancelled. This fixes it.")
     @Config.Name("Fix Right Clicking Parasite Entities")
     @Config.RequiresMcRestart
     @MixinConfig.MixinToggle(lateMixin = "mixins.srpmixins.srp.parasiterightclickfix.json", defaultValue = true)

--- a/src/main/java/srpmixins/config/folders/VariousConfig.java
+++ b/src/main/java/srpmixins/config/folders/VariousConfig.java
@@ -73,6 +73,12 @@ public class VariousConfig {
     @MixinConfig.MixinToggle(lateMixin = "mixins.srpmixins.srp.emptywhitelistfix.json", defaultValue = true)
     public boolean fixEmptyWhitelist = true;
 
+    @Config.Comment("Some parasites have broken right click handling when looking at them and will cancel all right click actions such as raising shields and drinking potions. This fixes it.")
+    @Config.Name("Fix Right Clicking Parasite Entities")
+    @Config.RequiresMcRestart
+    @MixinConfig.MixinToggle(lateMixin = "mixins.srpmixins.srp.parasiterightclickfix.json", defaultValue = true)
+    public boolean fixParasiteMobRightClick = true;
+
     @Config.Comment("Waves and Shockwaves are normal Parasite Entities and thus get lots of normal parasite behavior, for example the ability to target any mob once the phase is above phase total slaughter. This makes the wave instantly die though. This fixes it.")
     @Config.Name("Fix Wave Entities Early Death")
     @Config.RequiresMcRestart

--- a/src/main/java/srpmixins/mixin/features/EntityParasiteBase_AllowRightClick.java
+++ b/src/main/java/srpmixins/mixin/features/EntityParasiteBase_AllowRightClick.java
@@ -18,7 +18,6 @@ import org.spongepowered.asm.mixin.injection.At;
         EntityPMalleable.class
 })
 public abstract class EntityParasiteBase_AllowRightClick extends EntityParasiteBase {
-
     public EntityParasiteBase_AllowRightClick(World worldIn) {
         super(worldIn);
     }
@@ -28,7 +27,7 @@ public abstract class EntityParasiteBase_AllowRightClick extends EntityParasiteB
             method = "processInteract",
             at = @At(value = "RETURN", ordinal = 0)
     )
-    public boolean srpmixins_rightClickAdapted(boolean original, @Local(argsOnly = true) EntityPlayer player, @Local(argsOnly = true) EnumHand hand){
+    public boolean srpmixins_rightClickAdapted(boolean original, EntityPlayer player, EnumHand hand){
         return super.processInteract(player, hand);
     }
 }

--- a/src/main/java/srpmixins/mixin/features/EntityParasiteBase_AllowRightClick.java
+++ b/src/main/java/srpmixins/mixin/features/EntityParasiteBase_AllowRightClick.java
@@ -1,0 +1,34 @@
+package srpmixins.mixin.features;
+
+import com.dhanantry.scapeandrunparasites.entity.ai.misc.EntityPMalleable;
+import com.dhanantry.scapeandrunparasites.entity.ai.misc.EntityParasiteBase;
+import com.dhanantry.scapeandrunparasites.entity.monster.deterrent.EntityDodT;
+import com.dhanantry.scapeandrunparasites.entity.monster.deterrent.EntityNak;
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
+import com.llamalad7.mixinextras.sugar.Local;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.util.EnumHand;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(value = {
+        EntityDodT.class,
+        EntityNak.class,
+        EntityPMalleable.class
+})
+public abstract class EntityParasiteBase_AllowRightClick extends EntityParasiteBase {
+
+    public EntityParasiteBase_AllowRightClick(World worldIn) {
+        super(worldIn);
+    }
+
+    // Replace client always returning true with a super call
+    @ModifyReturnValue(
+            method = "processInteract",
+            at = @At(value = "RETURN", ordinal = 0)
+    )
+    public boolean srpmixins_rightClickAdapted(boolean original, @Local(argsOnly = true) EntityPlayer player, @Local(argsOnly = true) EnumHand hand){
+        return super.processInteract(player, hand);
+    }
+}

--- a/src/main/resources/mixins.srpmixins.srp.parasiterightclickfix.json
+++ b/src/main/resources/mixins.srpmixins.srp.parasiterightclickfix.json
@@ -1,0 +1,14 @@
+{
+  "required": true,
+  "package": "srpmixins.mixin.features",
+  "refmap": "mixins.srpmixins.refmap.json",
+  "compatibilityLevel": "JAVA_8",
+  "target": "@env(DEFAULT)",
+  "minVersion": "0.8",
+  "mixins": [
+    "EntityParasiteBase_AllowRightClick"
+  ],
+  "injectors": {
+    "maxShiftBy": 10
+  }
+}


### PR DESCRIPTION
It kill iqury

    @Config.Comment("Some parasites have broken right click handling when looking at them and will cancel all right click actions such as raising shields and drinking potions. This fixes it.")
    @Config.Name("Fix Right Clicking Parasite Entities")